### PR TITLE
Fix service worker caching of unsupported schemes

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -148,6 +148,11 @@ self.addEventListener('fetch', event => {
   const { request } = event;
   const url = new URL(request.url);
 
+  // Only handle http(s) requests
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return;
+  }
+
   // Skip non-GET requests
   if (request.method !== 'GET') {
     return;


### PR DESCRIPTION
## Summary
- ignore non-http fetch requests in the service worker

## Testing
- `npm run lint` *(fails: eslint config not installed)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a748f1138832b9f9506cb74e95a55